### PR TITLE
Make SimSYCL thread-safe

### DIFF
--- a/include/simsycl/detail/check.hh
+++ b/include/simsycl/detail/check.hh
@@ -14,6 +14,7 @@ void check(
     bool condition, const char *cond_string, std::source_location location, int default_mode, const char *message, ...);
 
 struct override_check_mode {
+    // effect is thread-local
     override_check_mode(int mode);
     ~override_check_mode();
 };

--- a/include/simsycl/detail/lock.hh
+++ b/include/simsycl/detail/lock.hh
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <cassert>
+#include <mutex>
+#include <utility>
+
+
+namespace simsycl::detail {
+
+class system_lock {
+  public:
+    system_lock();
+
+  private:
+    template<typename F>
+    friend decltype(auto) with_system_lock(F &&f);
+
+    std::lock_guard<std::recursive_mutex> m_lock;
+};
+
+template<typename T>
+class shared_value {
+  public:
+    shared_value() : m_value() {}
+    shared_value(const T &v) : m_value(v) {}
+    shared_value(T &&v) : m_value(std::move(v)) {}
+
+    template<typename... Params>
+    shared_value(const std::in_place_t /* tag */, Params &&...params) : m_value(std::forward<Params>(params)...) {}
+
+    shared_value(const shared_value &) = delete;
+    shared_value(shared_value &&) = delete;
+    shared_value &operator=(const shared_value &) = delete;
+    shared_value &operator=(shared_value &&) = delete;
+
+    ~shared_value() = default;
+
+    T &with(system_lock & /* lock */) { return m_value; }
+
+  private:
+    T m_value;
+};
+
+} // namespace simsycl::detail

--- a/include/simsycl/detail/reference_type.hh
+++ b/include/simsycl/detail/reference_type.hh
@@ -45,7 +45,7 @@ class reference_type {
         static_assert(std::is_base_of_v<reference_type, Derived>);
     }
 
-    state_type &state() const {
+    const state_type &state() const {
         SIMSYCL_CHECK(m_state != nullptr);
         return *m_state;
     }

--- a/include/simsycl/schedule.hh
+++ b/include/simsycl/schedule.hh
@@ -40,7 +40,8 @@ class shuffle_schedule final : public cooperative_schedule {
     uint64_t m_seed = 1234567890;
 };
 
+// effect is thread-local
 const cooperative_schedule &get_cooperative_schedule();
-void set_cooperative_schedule(std::unique_ptr<cooperative_schedule> schedule);
+void set_cooperative_schedule(std::shared_ptr<const cooperative_schedule> schedule);
 
 } // namespace simsycl

--- a/include/simsycl/sycl/accessor.hh
+++ b/include/simsycl/sycl/accessor.hh
@@ -205,8 +205,8 @@ class accessor : public simsycl::detail::property_interface {
     using const_reference = const DataT &;
 
     template<access::decorated IsDecorated>
-    using accessor_ptr = std::enable_if_t<AccessTarget == target::device && IsDecorated == IsDecorated /* dependent */,
-        multi_ptr<value_type, access::address_space::global_space, IsDecorated>>;
+        requires(AccessTarget == target::device)
+    using accessor_ptr = multi_ptr<value_type, access::address_space::global_space, IsDecorated>;
 
     using iterator = simsycl::detail::accessor_iterator<accessor, value_type, Dimensions>;
     using const_iterator = simsycl::detail::accessor_iterator<accessor, const value_type, Dimensions>;
@@ -493,8 +493,8 @@ class accessor<DataT, 0, AccessMode, AccessTarget, IsPlaceholder> : public simsy
     using const_reference = const DataT &;
 
     template<access::decorated IsDecorated>
-    using accessor_ptr = std::enable_if_t<AccessTarget == target::device && IsDecorated == IsDecorated /* dependent */,
-        multi_ptr<value_type, access::address_space::global_space, IsDecorated>>;
+        requires(AccessTarget == target::device)
+    using accessor_ptr = multi_ptr<value_type, access::address_space::global_space, IsDecorated>;
 
     using iterator = simsycl::detail::accessor_iterator<accessor, value_type, 0>;
     using const_iterator = simsycl::detail::accessor_iterator<accessor, const value_type, 0>;

--- a/include/simsycl/sycl/device.hh
+++ b/include/simsycl/sycl/device.hh
@@ -40,8 +40,9 @@ struct accelerator_selector {
 };
 
 struct device_state;
+class system_lock;
 
-size_t *device_bytes_free(const sycl::device &device);
+size_t &device_bytes_free(const sycl::device &device, system_lock &lock);
 
 } // namespace simsycl::detail
 
@@ -109,7 +110,7 @@ class device final : public detail::reference_type<device, detail::device_state>
 
     friend device simsycl::make_device(sycl::platform &platform, const device_config &config);
     friend void simsycl::set_parent_device(sycl::device &device, const sycl::device &parent);
-    friend size_t *detail::device_bytes_free(const sycl::device &device);
+    friend size_t &detail::device_bytes_free(const sycl::device &device, detail::system_lock &lock);
 
     device(const detail::device_selector &selector);
     device(std::shared_ptr<detail::device_state> &&state) : reference_type(std::move(state)) {}

--- a/include/simsycl/sycl/device_selector.hh
+++ b/include/simsycl/sycl/device_selector.hh
@@ -6,7 +6,7 @@ namespace simsycl::sycl {
 
 class device_selector {
   public:
-    device_selector(){};
+    device_selector() {}
 
     device_selector(const device_selector &rhs) { (void)rhs; };
 
@@ -15,7 +15,7 @@ class device_selector {
         return *this;
     };
 
-    virtual ~device_selector(){};
+    virtual ~device_selector() {}
 
     device select_device() const { return {}; }
 

--- a/include/simsycl/sycl/event.hh
+++ b/include/simsycl/sycl/event.hh
@@ -13,21 +13,15 @@
 namespace simsycl::detail {
 
 struct event_state {
-    std::chrono::steady_clock::time_point t_submit{};
-    std::chrono::steady_clock::time_point t_start{};
-    std::chrono::steady_clock::time_point t_end{};
+    std::chrono::steady_clock::time_point t_submit;
+    std::chrono::steady_clock::time_point t_start;
+    std::chrono::steady_clock::time_point t_end;
 
     void start() { t_start = std::chrono::steady_clock::now(); }
 
     [[nodiscard]] static event_state submit() {
         event_state status;
         status.t_submit = std::chrono::steady_clock::now();
-        return status;
-    }
-
-    [[nodiscard]] static event_state submit_and_start() {
-        auto status = submit();
-        status.start();
         return status;
     }
 
@@ -118,6 +112,9 @@ inline sycl::event event_state::end() {
     return make_event(*this);
 }
 
-inline sycl::event event_state::instant() { return submit_and_start().end(); }
+inline sycl::event event_state::instant() {
+    const auto now = std::chrono::steady_clock::now();
+    return make_event(event_state{now, now, now});
+}
 
 } // namespace simsycl::detail

--- a/include/simsycl/sycl/exception.hh
+++ b/include/simsycl/sycl/exception.hh
@@ -11,21 +11,21 @@ namespace simsycl::sycl {
 
 class exception : public virtual std::exception {
   public:
-    exception(std::error_code ec, const std::string &what_arg) : m_error(ec, what_arg){};
-    exception(std::error_code ec, const char *what_arg) : m_error(ec, what_arg){};
-    exception(std::error_code ec) : m_error(ec){};
-    exception(int ev, const std::error_category &ecat, const std::string &what_arg) : m_error(ev, ecat, what_arg){};
-    exception(int ev, const std::error_category &ecat, const char *what_arg) : m_error(ev, ecat, what_arg){};
-    exception(int ev, const std::error_category &ecat) : m_error(ev, ecat){};
+    exception(std::error_code ec, const std::string &what_arg) : m_error(ec, what_arg) {}
+    exception(std::error_code ec, const char *what_arg) : m_error(ec, what_arg) {}
+    exception(std::error_code ec) : m_error(ec) {}
+    exception(int ev, const std::error_category &ecat, const std::string &what_arg) : m_error(ev, ecat, what_arg) {}
+    exception(int ev, const std::error_category &ecat, const char *what_arg) : m_error(ev, ecat, what_arg) {}
+    exception(int ev, const std::error_category &ecat) : m_error(ev, ecat) {}
 
-    exception(context ctx, std::error_code ec, const std::string &what_arg) : m_error(ec, what_arg), m_context(ctx){};
-    exception(context ctx, std::error_code ec, const char *what_arg) : m_error(ec, what_arg), m_context(ctx){};
-    exception(context ctx, std::error_code ec) : m_error(ec), m_context(ctx){};
+    exception(context ctx, std::error_code ec, const std::string &what_arg) : m_error(ec, what_arg), m_context(ctx) {}
+    exception(context ctx, std::error_code ec, const char *what_arg) : m_error(ec, what_arg), m_context(ctx) {}
+    exception(context ctx, std::error_code ec) : m_error(ec), m_context(ctx) {}
     exception(context ctx, int ev, const std::error_category &ecat, const std::string &what_arg)
-        : m_error(ev, ecat, what_arg), m_context(ctx){};
+        : m_error(ev, ecat, what_arg), m_context(ctx) {}
     exception(context ctx, int ev, const std::error_category &ecat, const char *what_arg)
-        : m_error(ev, ecat, what_arg), m_context(ctx){};
-    exception(context ctx, int ev, const std::error_category &ecat) : m_error(ev, ecat), m_context(ctx){};
+        : m_error(ev, ecat, what_arg), m_context(ctx) {}
+    exception(context ctx, int ev, const std::error_category &ecat) : m_error(ev, ecat), m_context(ctx) {}
 
     const std::error_code &code() const noexcept { return m_error.code(); }
     const std::error_category &category() const noexcept { return m_error.code().category(); }

--- a/include/simsycl/sycl/forward.hh
+++ b/include/simsycl/sycl/forward.hh
@@ -148,6 +148,7 @@ class vec;
 namespace simsycl::detail {
 
 class unnamed_kernel;
+class system_lock;
 
 struct concurrent_nd_item;
 struct concurrent_group;
@@ -169,7 +170,8 @@ template<typename T, int Dimensions, typename AllocatorT>
 T *get_buffer_data(sycl::buffer<T, Dimensions, AllocatorT> &buf);
 
 template<typename T, int Dimensions, typename AllocatorT>
-buffer_access_validator<Dimensions> &get_buffer_access_validator(const sycl::buffer<T, Dimensions, AllocatorT> &buf);
+buffer_access_validator<Dimensions> &get_buffer_access_validator(
+    const sycl::buffer<T, Dimensions, AllocatorT> &buf, system_lock &lock);
 
 sycl::handler make_handler(const sycl::device &device);
 

--- a/include/simsycl/sycl/platform.hh
+++ b/include/simsycl/sycl/platform.hh
@@ -23,6 +23,7 @@ sycl::device make_device(sycl::platform &platform, const device_config &config);
 
 namespace simsycl::detail {
 
+class system_lock;
 struct platform_state;
 
 } // namespace simsycl::detail
@@ -65,7 +66,7 @@ class platform final : public detail::reference_type<platform, detail::platform_
     platform(const detail::device_selector &selector);
     platform(std::shared_ptr<detail::platform_state> &&state) : reference_type(std::move(state)) {}
 
-    void add_device(const device &dev);
+    void add_device(const device &dev, detail::system_lock &lock);
 };
 
 } // namespace simsycl::sycl

--- a/include/simsycl/sycl/queue.hh
+++ b/include/simsycl/sycl/queue.hh
@@ -5,6 +5,7 @@
 #include "handler.hh"
 #include "property.hh"
 
+#include "../detail/lock.hh"
 #include "../detail/reference_type.hh"
 
 
@@ -91,6 +92,7 @@ class queue final : public detail::reference_type<queue, detail::queue_state>,
     template<typename T>
     event submit(T cgf) {
         auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
         auto cgh = simsycl::detail::make_handler(get_device());
         status.start();
         cgf(cgh);
@@ -230,26 +232,34 @@ class queue final : public detail::reference_type<queue, detail::queue_state>,
     /* -- USM functions -- */
 
     event memcpy(void *dest, const void *src, size_t num_bytes) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         ::memcpy(dest, src, num_bytes);
         return status.end();
     }
 
     event memcpy(void *dest, const void *src, size_t num_bytes, event /* dep_event */) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         ::memcpy(dest, src, num_bytes);
         return status.end();
     }
 
     event memcpy(void *dest, const void *src, size_t num_bytes, const std::vector<event> & /* dep_events */) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         ::memcpy(dest, src, num_bytes);
         return status.end();
     }
 
     template<typename T>
     event copy(const T *src, T *dest, size_t count) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         std::copy_n(src, count, dest);
         return status.end();
     }
@@ -257,7 +267,9 @@ class queue final : public detail::reference_type<queue, detail::queue_state>,
     template<typename T>
     event copy(const T *src, T *dest, size_t count, event dep_event) {
         (void)(dep_event);
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         std::copy_n(src, count, dest);
         return status.end();
     }
@@ -265,46 +277,60 @@ class queue final : public detail::reference_type<queue, detail::queue_state>,
     template<typename T>
     event copy(const T *src, T *dest, size_t count, const std::vector<event> &dep_events) {
         (void)(dep_events);
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         std::copy_n(src, count, dest);
         return status.end();
     }
 
     event memset(void *ptr, int value, size_t num_bytes) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         ::memset(ptr, value, num_bytes);
         return status.end();
     }
 
     event memset(void *ptr, int value, size_t num_bytes, event /* dep_event */) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         ::memset(ptr, value, num_bytes);
         return status.end();
     }
 
     event memset(void *ptr, int value, size_t num_bytes, const std::vector<event> & /* dep_events */) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         ::memset(ptr, value, num_bytes);
         return status.end();
     }
 
     template<typename T>
     event fill(void *ptr, const T &pattern, size_t count) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         std::fill_n(static_cast<T *>(ptr), count, pattern);
         return status.end();
     }
 
     template<typename T>
     event fill(void *ptr, const T &pattern, size_t count, event /* dep_event */) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         std::fill_n(static_cast<T *>(ptr), count, pattern);
         return status.end();
     }
 
     template<typename T>
     event fill(void *ptr, const T &pattern, size_t count, const std::vector<event> & /* dep_events */) {
-        auto status = detail::event_state::submit_and_start();
+        auto status = detail::event_state::submit();
+        detail::system_lock lock; // implicitly enforce dependency ordering by keeping a lock within every task
+        status.start();
         std::fill_n(static_cast<T *>(ptr), count, pattern);
         return status.end();
     }

--- a/include/simsycl/system.hh
+++ b/include/simsycl/system.hh
@@ -10,6 +10,8 @@
 
 namespace simsycl {
 
+class cooperative_schedule;
+
 using platform_id = std::string;
 using device_id = std::string;
 using system_id = std::string;
@@ -117,12 +119,14 @@ system_config read_system_config(const std::string &path_to_json_file);
 void write_system_config(const std::string &path_to_json_file, const system_config &config);
 void configure_system(const system_config &system);
 
+std::shared_ptr<const cooperative_schedule> get_default_cooperative_schedule();
+
 } // namespace simsycl
 
 namespace simsycl::detail {
 
-const std::vector<sycl::platform> &get_platforms();
-const std::vector<sycl::device> &get_devices();
+const std::vector<sycl::platform> &get_platforms(system_lock &lock);
+const std::vector<sycl::device> &get_devices(system_lock &lock);
 sycl::device select_device(const device_selector &selector);
 
 } // namespace simsycl::detail

--- a/src/simsycl/check.cc
+++ b/src/simsycl/check.cc
@@ -19,7 +19,7 @@ std::string format_error(const char *cond_string, std::source_location location)
 namespace simsycl::detail {
 
 constexpr int no_check_override = 0;
-int g_check_mode_override = no_check_override;
+thread_local int g_check_mode_override = no_check_override;
 
 override_check_mode::override_check_mode(int mode) {
     assert(g_check_mode_override == no_check_override && "check mode already overridden");

--- a/test/math_tests.cc
+++ b/test/math_tests.cc
@@ -34,7 +34,7 @@ TEST_CASE("Length function works as expected", "[math][geometric]") {
 
 #if SIMSYCL_FEATURE_HALF_TYPE
     using sycl::half;
-    half h = 7.0f;
+    half h = static_cast<half>(7.0f);
     auto vh1 = vec<half, 2>(half(3.0), half(4.0));
     CHECK(length(h) == Catch::Approx(7.0f));
     CHECK(length(vh1) == Catch::Approx(5.0f));


### PR DESCRIPTION
Overall, SimSYCL has very little shared mutable state:

Fiber scheduling always happens inside a `parallel_for`, so it will never cross thread boundaries. The corresponding `cooperative_schedule` and "return fiber" can be made thread-local.

For where there is globally visible shared state (system config, USM allocations, buffer access validation), I've introduced a global lock (named `system_lock`, which is backed by a singleton mutex). All shared mutable state is now explicitly wrapped in a `mutable shared_state<>`, which only grants access to its interior when a `system_lock` is in scope.

To guarantee command-group ordering across threads without tracking dependencies explicitly, `submit` (and all similar functions) hold the `system_lock` while they're running.

With this patch, Celerity works fine on my machine :tm: [with workarounds removed](https://github.com/celerity/celerity-runtime/tree/thread-safe-simsycl).