### PR TITLE
Properly implement `handler::update_host`

### DIFF
--- a/include/simsycl/sycl/forward.hh
+++ b/include/simsycl/sycl/forward.hh
@@ -163,15 +163,15 @@ concurrent_sub_group &get_concurrent_group(const sycl::sub_group &g);
 template<int Dimensions>
 concurrent_group &get_concurrent_group(const sycl::group<Dimensions> &g);
 
+template<typename T, int Dimensions>
+struct buffer_state;
+
 template<int Dimensions>
 struct buffer_access_validator;
 
 template<typename T, int Dimensions, typename AllocatorT>
-T *get_buffer_data(sycl::buffer<T, Dimensions, AllocatorT> &buf);
-
-template<typename T, int Dimensions, typename AllocatorT>
-buffer_access_validator<Dimensions> &get_buffer_access_validator(
-    const sycl::buffer<T, Dimensions, AllocatorT> &buf, system_lock &lock);
+const buffer_state<std::remove_const_t<T>, Dimensions> &get_buffer_state(
+    const sycl::buffer<T, Dimensions, AllocatorT> &buf);
 
 sycl::handler make_handler(const sycl::device &device);
 

--- a/include/simsycl/sycl/handler.hh
+++ b/include/simsycl/sycl/handler.hh
@@ -189,9 +189,11 @@ class handler {
         accessor<DestT, DestDim, DestMode, DestTgt, DestIsPlaceholder> dest) {
         static_assert(sizeof(SrcT) == sizeof(DestT));
         static_assert(SrcDim == DestDim, "copy between different accessor dimensions not implemented");
-        assert(src.get_range() == dest.get_range() && "copy between differently-ranged accessors not implemented");
-        detail::memcpy_strided_host(src.get_pointer(), dest.get_pointer(), sizeof(SrcT), src.get_buffer_range(),
-            src.get_offset(), dest.get_buffer_range(), dest.get_offset(), dest.get_range());
+        if constexpr(SrcDim == DestDim) { // stop printing follow-up compiler errors if the above static_assert fails
+            assert(src.get_range() == dest.get_range() && "copy between differently-ranged accessors not implemented");
+            detail::memcpy_strided_host(src.get_pointer(), dest.get_pointer(), sizeof(SrcT), src.get_buffer_range(),
+                src.get_offset(), dest.get_buffer_range(), dest.get_offset(), dest.get_range());
+        }
     }
 
     template<typename T, int Dim, access_mode Mode, target Tgt, access::placeholder IsPlaceholder>

--- a/include/simsycl/sycl/reduction.hh
+++ b/include/simsycl/sycl/reduction.hh
@@ -162,7 +162,7 @@ auto reduction(buffer<T, Dimensions, AllocatorT> &vars, handler &cgh, BinaryOper
     const property_list &prop_list = {}) {
     (void)cgh;
     SIMSYCL_CHECK(vars.get_range().size() == 1);
-    T *value = detail::get_buffer_data(vars);
+    T *value = detail::get_buffer_state(vars).data;
     detail::begin_reduction(value, combiner, nullptr, prop_list);
     return detail::reducer<T, BinaryOperation, 0>(value, combiner);
 }
@@ -183,7 +183,7 @@ auto reduction(buffer<T, Dimensions, AllocatorT> &vars, handler &cgh, const T &i
     const property_list &prop_list = {}) {
     (void)cgh;
     SIMSYCL_CHECK(vars.get_range().size() == 1);
-    T *value = detail::get_buffer_data(vars);
+    T *value = detail::get_buffer_state(vars).data;
     detail::begin_reduction(value, combiner, &identity, prop_list);
     return detail::reducer<T, BinaryOperation, 0>(value, combiner);
 }

--- a/test/reduction_tests.cc
+++ b/test/reduction_tests.cc
@@ -58,11 +58,11 @@ TEMPLATE_TEST_CASE(
         })
         .wait();
 
-    CHECK(*detail::get_buffer_data(plus_buf) == 100 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
+    CHECK(*detail::get_buffer_state(plus_buf).data == 100 + 0 + 1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9);
     CHECK(mult_var == 1 * 2 * 3 * 4 * 5 * 6 * 7 * 8 * 9 * 10);
-    CHECK(*detail::get_buffer_data(bit_and_buf) == 16);
+    CHECK(*detail::get_buffer_state(bit_and_buf).data == 16);
     CHECK(bit_or_var == (128 | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9));
-    CHECK(*detail::get_buffer_data(bit_xor_buf) == (0 ^ 1 ^ 2 ^ 3 ^ 4 ^ 5 ^ 6 ^ 7 ^ 8 ^ 9));
+    CHECK(*detail::get_buffer_state(bit_xor_buf).data == (0 ^ 1 ^ 2 ^ 3 ^ 4 ^ 5 ^ 6 ^ 7 ^ 8 ^ 9));
     CHECK(min_var == -4.0f);
     CHECK(max_var == 9.0f);
 }


### PR DESCRIPTION
The function was not callable so far, it simply referenced an unimplemented function on `accessor` of the same name.

Calling `buffer_state::write_back` requires the state to be available inside `accessor`, which is why I refactored `buffer` to internally expose its `state` rather than pointers and ranges individually. This in turn needs type erasure on Allocator, which I quickly added as well.