### PR TITLE
Implement `property::buffer::context_bound::get_context()`

### DIFF
--- a/include/simsycl/sycl/buffer.hh
+++ b/include/simsycl/sycl/buffer.hh
@@ -35,7 +35,7 @@ class context_bound {
   public:
     context_bound(context bound_context) : m_context(std::move(bound_context)) {}
 
-    context get_context() const;
+    context get_context() const { return m_context; }
 
   private:
     context m_context;


### PR DESCRIPTION
This was missing its (trivial) implementation.