### PR TITLE
Fix implementation of `handler::fill`

### DIFF
--- a/include/simsycl/sycl/handler.hh
+++ b/include/simsycl/sycl/handler.hh
@@ -201,7 +201,7 @@ class handler {
 
     template<typename T, int Dim, access_mode Mode, target Tgt, access::placeholder IsPlaceholder>
     void fill(accessor<T, Dim, Mode, Tgt, IsPlaceholder> dest, const T &src) {
-        detail::sequential_for(dest.get_range(), dest.get_offset(), [&](const item<Dim> &item) { dest[item] = src; });
+        parallel_for(dest.get_range(), dest.get_offset(), [&](item<Dim> item) { dest[item] = src; });
     }
 
     SIMSYCL_STOP_IGNORING_DEPRECATIONS


### PR DESCRIPTION
`fill` is just a kernel, it was implemented with the internal `sequential_for` helper instead of `handler::parallel_for` - not sure exactly what didn't work, but afaic this is the more straightforward implementation anyway.