### PR TITLE
Tooling: Track and verify CTS state

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 SimSYCL is a single-threaded, synchronous, library-only implementation of the SYCL 2020 specification. It enables you to test your SYCL applications against simulated hardware of different characteristics and discover bugs with its extensive verification capabilities.
 
-SimSYCL is in a very early stage of development - try it at your own risk!
+## Implementation progress
+
+SimSYCL is still under development, but it already passes a large portion of the [SYCL Conformance Test Suite](https://github.com/KhronosGroup/SYCL-CTS):
+
+![SYCL spec conformance by CTS test suites passed](resources/cts_state.svg)
 
 ## Requirements
 

--- a/ci/confirm_cts_state.py
+++ b/ci/confirm_cts_state.py
@@ -1,0 +1,72 @@
+"""
+Attempts building & running all CTS category targets in an existing build directory and compares
+their passing / failing with the info from `cts_state.csv`. If the two sources differ, reports
+their disparities and exits with a non-zero code.
+"""
+
+from argparse import ArgumentParser
+from operator import itemgetter
+import os
+import subprocess
+import sys
+
+import pandas as pd
+
+parser = ArgumentParser()
+parser.add_argument('cts_root', type=str, help='SYCL-CTS repository path')
+parser.add_argument('cts_build_dir', type=str, help='SYCL-CTS + SimSYCL build directory')
+args = parser.parse_args()
+cts_root = os.path.realpath(args.cts_root)
+cts_build_dir = os.path.realpath(args.cts_build_dir)
+
+state_file = pd.read_csv('ci/cts_state.csv', delimiter=';')
+tests_in_state_file = set(state_file['suite'])
+
+tests_dir = os.path.join(cts_root, 'tests')
+tests_in_cts = set(t for t in os.listdir(tests_dir)
+                   if os.path.isdir(os.path.join(tests_dir, t))
+                   and t not in ['common', 'extension'])
+
+n_build_failed = 0
+n_run_failed = 0
+n_passed = 0
+changed = []
+for test in sorted(tests_in_cts):
+    status_in_state_file = state_file['status'][state_file['suite'] == test].values
+    status_in_state_file = status_in_state_file[0] if status_in_state_file.size > 0 else 'not in list'
+    if status_in_state_file == 'not applicable': continue
+
+    print('testing', test, end='... ', flush=True)
+    r = subprocess.run(['cmake', '--build', cts_build_dir, '--target', f'test_{test}'],
+                       cwd=cts_root, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    if r.returncode == 0:
+        r = subprocess.run(os.path.join(cts_build_dir, 'bin', f'test_{test}'), cwd=cts_root,
+                           stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if r.returncode == 0:
+            status_now = 'passed'
+            n_passed += 1
+        else:
+            status_now = 'run failed'
+            n_run_failed += 1
+    else:
+        status_now = 'build failed'
+        n_build_failed += 1
+
+    if status_now == status_in_state_file:
+        print(status_now)
+    else:
+        print(f'{status_now}, but was {status_in_state_file}')
+        changed.append((test, status_in_state_file, status_now))
+
+print(f'\n{n_passed} passed, {n_run_failed} failed to run, {n_build_failed} failed to build')
+
+for test in tests_in_state_file - tests_in_cts:
+    status_in_state_file = state_file['status'][state_file['suite'] == test].values[0]
+    changed.append((test, status_in_state_file, 'not in SYCL-CTS'))
+
+if changed:
+    print(f'\n{len(changed)} change(s) compared to cts_state.csv:')
+    changed.sort(key=itemgetter(0))
+    for test, status_in_state_file, status_now in changed:
+        print(f'  - {test}: {status_in_state_file} -> {status_now}')
+    sys.exit(1)

--- a/ci/cts_state.csv
+++ b/ci/cts_state.csv
@@ -1,0 +1,76 @@
+suite;status;reason
+accessor_basic;run failed;accessor implicit conversions
+accessor_generic;run failed;everything
+accessor_legacy;build failed;image targets, sycl::atomic NYI
+accessor_placeholder;run failed;conditions check (investigate)
+address_space;passed;
+atomic;build failed;deprecated atomic types (return values of accessor<atomic>::operator[])
+atomic_fence;passed;
+atomic_ref;passed;
+atomic_ref_stress;passed;
+bit_cast;passed;
+buffer;run failed;sub-buffers NYI
+context;passed;
+cuda_interop;not applicable;
+device;run failed;sub-devices NYI
+device_event;passed;
+device_selector;passed;
+error;passed;
+event;run failed;async_handler NYI, Limitation: no asynchronicity between application thread and host tasks
+exception_handling;build failed;sub-devices NYI
+exceptions;run failed;"async" error handling NYI
+full_feature_set;passed;
+function_objects;passed;
+group;passed;
+group_functions;run failed;group scan defective?
+handler;run failed;hierarchical parallel for requires known local range
+header;passed;
+hierarchical;passed;
+h_item;passed;
+host_accessor;run failed;reference semantics (copy equality), ...
+host_task;passed;
+id;passed;
+image;build failed;images NYI
+image_accessor;build failed;images NYI
+invoke;run failed;parallel_for 2D / 3D short-hands NYI
+is_device_copyable;passed;
+item;passed;
+kernel;build failed;kernel bundle global functions NYI
+kernel_args;build failed;samplers NYI
+kernel_bundle;build failed;device_image NYI, ...
+language;passed;
+local_accessor;run failed;reference semantics (copy equality), ...
+marray_arithmetic_assignment;passed;
+marray_arithmetic_binary;passed;
+marray_basic;passed;
+marray_bitwise;passed;
+marray_pre_post;passed;
+marray_relational;passed;
+math_builtin_api;build failed;math functions incomplete (only using std)
+multi_ptr;build failed;multi_ptr<legacy> == element* is ambiguous (incorrect in CTS / DPC++?)
+namespace;passed;
+nd_item;passed;
+nd_range;passed;
+opencl_interop;not applicable;
+optional_kernel_features;run failed;incorrect exception codes thrown (investigate)
+platform;passed;
+pointers;passed;
+property;passed;
+queue;passed;
+range;passed;
+reduction;build failed;reductions on `span` NYI
+sampler;build failed;samplers / images NYI
+scalars;passed;
+spec_constants;build failed;use_kernel_bundle() and associated checking NYI
+stream;build failed;sycl:stream NYI
+sub_group;passed;
+sycl_external;run failed;UBSan: reached an unreachable program point in kernel_between_aspects, Clang compiler bug?
+usm;passed;Limitation: SimSYCL cannot communicate from main thread to kernel through SHMEM
+vector_alias;passed;
+vector_api;run failed;convert() tests fail because rounding modes are NYI
+vector_constructors;passed;
+vector_deduction_guides;passed;
+vector_load_store;passed;
+vector_operators;passed;
+vector_swizzle_assignment;passed;
+vector_swizzles;passed;

--- a/ci/render_cts_state.py
+++ b/ci/render_cts_state.py
@@ -1,0 +1,33 @@
+"""
+Renders the ratios from `cts_state.csv` as `resources/cts_state.svg`.
+"""
+
+import os
+
+import pandas as pd
+from matplotlib import pyplot as plt
+
+os.chdir(os.path.join(os.path.dirname(__file__), os.path.pardir))
+
+state = pd.read_csv('ci/cts_state.csv', delimiter=';')
+counts = state.groupby('status').agg(count=('suite', 'size'))['count'].to_dict()
+
+labels = ['passed', 'run failed', 'build failed', 'not applicable']
+colors = ['#4a0', '#fa0', '#e44', '#aaa']
+
+plt.rcParams['svg.fonttype'] = 'none'
+
+fig, ax = plt.subplots(figsize=(8, 0.6))
+left = 0
+for l, c in zip(labels, colors):
+    n = counts[l]
+    ax.barh(0, n, left=left, color=c, label=l)
+    ax.text(left + n/2, 0, str(n), ha='center', va='center', weight='bold')
+    left += n
+ax.set_xlim(0, left)
+ax.axis('off')
+ax.set_title('SimSYCL spec conformance by number of CTS categories')
+
+fig.legend(loc='lower center', ncols=len(labels),
+           bbox_to_anchor=(0, -0.4, 1, 0.5), frameon=False)
+fig.savefig('resources/cts_state.svg', bbox_inches='tight')

--- a/resources/cts_state.svg
+++ b/resources/cts_state.svg
@@ -1,0 +1,132 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="460.8pt" height="79.814125pt" viewBox="0 0 460.8 79.814125" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2025-01-08T15:39:06.924859</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.3, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 79.814125 
+L 460.8 79.814125 
+L 460.8 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 7.2 54.070125 
+L 269.088 54.070125 
+L 269.088 23.830125 
+L 7.2 23.830125 
+z
+" clip-path="url(#p2260dbeb65)" style="fill: #44aa00"/>
+   </g>
+   <g id="patch_3">
+    <path d="M 269.088 54.070125 
+L 358.368 54.070125 
+L 358.368 23.830125 
+L 269.088 23.830125 
+z
+" clip-path="url(#p2260dbeb65)" style="fill: #ffaa00"/>
+   </g>
+   <g id="patch_4">
+    <path d="M 358.368 54.070125 
+L 441.696 54.070125 
+L 441.696 23.830125 
+L 358.368 23.830125 
+z
+" clip-path="url(#p2260dbeb65)" style="fill: #ee4444"/>
+   </g>
+   <g id="patch_5">
+    <path d="M 441.696 54.070125 
+L 453.6 54.070125 
+L 453.6 23.830125 
+L 441.696 23.830125 
+z
+" clip-path="url(#p2260dbeb65)" style="fill: #aaaaaa"/>
+   </g>
+   <g id="text_1">
+    <text style="font: 700 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="138.144" y="41.7095" transform="rotate(-0 138.144 41.7095)">44</text>
+   </g>
+   <g id="text_2">
+    <text style="font: 700 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="313.728" y="41.7095" transform="rotate(-0 313.728 41.7095)">15</text>
+   </g>
+   <g id="text_3">
+    <text style="font: 700 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="400.032" y="41.7095" transform="rotate(-0 400.032 41.7095)">14</text>
+   </g>
+   <g id="text_4">
+    <text style="font: 700 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="447.648" y="41.7095" transform="rotate(-0 447.648 41.7095)">2</text>
+   </g>
+   <g id="text_5">
+    <text style="font: 12px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: middle" x="230.4" y="16.318125" transform="rotate(-0 230.4 16.318125)">SimSYCL spec conformance by number of CTS categories</text>
+   </g>
+  </g>
+  <g id="legend_1">
+   <g id="patch_6">
+    <path d="M 32.507813 66.534437 
+L 52.507813 66.534437 
+L 52.507813 59.534437 
+L 32.507813 59.534437 
+z
+" style="fill: #44aa00"/>
+   </g>
+   <g id="text_6">
+    <text style="font: 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="60.507813" y="66.534437" transform="rotate(-0 60.507813 66.534437)">passed</text>
+   </g>
+   <g id="patch_7">
+    <path d="M 115.904688 66.534437 
+L 135.904688 66.534437 
+L 135.904688 59.534437 
+L 115.904688 59.534437 
+z
+" style="fill: #ffaa00"/>
+   </g>
+   <g id="text_7">
+    <text style="font: 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="143.904688" y="66.534437" transform="rotate(-0 143.904688 66.534437)">run failed</text>
+   </g>
+   <g id="patch_8">
+    <path d="M 211.575 66.534437 
+L 231.575 66.534437 
+L 231.575 59.534437 
+L 211.575 59.534437 
+z
+" style="fill: #ee4444"/>
+   </g>
+   <g id="text_8">
+    <text style="font: 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="239.575" y="66.534437" transform="rotate(-0 239.575 66.534437)">build failed</text>
+   </g>
+   <g id="patch_9">
+    <path d="M 315.05 66.534437 
+L 335.05 66.534437 
+L 335.05 59.534437 
+L 315.05 59.534437 
+z
+" style="fill: #aaaaaa"/>
+   </g>
+   <g id="text_9">
+    <text style="font: 10px 'DejaVu Sans', 'Bitstream Vera Sans', 'Computer Modern Sans Serif', 'Lucida Grande', 'Verdana', 'Geneva', 'Lucid', 'Arial', 'Helvetica', 'Avant Garde', sans-serif; text-anchor: start" x="343.05" y="66.534437" transform="rotate(-0 343.05 66.534437)">not applicable</text>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="p2260dbeb65">
+   <rect x="7.2" y="22.318125" width="446.4" height="33.264"/>
+  </clipPath>
+ </defs>
+</svg>


### PR DESCRIPTION
Adds the "CTS State" Google Sheet I had lying around to the repo, and introduces a script to automatically build / run CTS tests to verify it's still up to date. This should make finding regressions and missed spec updates locally easier.

Eventually we want to integrate this into CI, but this requires KhronosGroup/SYCL-CTS/pull/871 to be merged first (+some CI integration work on our side).