### PR TITLE
Fix a few issues found by CppCheck

### DIFF
--- a/include/simsycl/sycl/multi_ptr.hh
+++ b/include/simsycl/sycl/multi_ptr.hh
@@ -91,12 +91,14 @@ class multi_ptr {
         requires(Space == access::address_space::generic_space && AS != access::address_space::constant_space)
     multi_ptr &operator=(const multi_ptr<value_type, AS, IsDecorated> &other) {
         m_ptr = other.m_ptr;
+        return *this;
     }
 
     template<access::address_space AS, access::decorated IsDecorated>
         requires(Space == access::address_space::generic_space && AS != access::address_space::constant_space)
     multi_ptr &operator=(multi_ptr<value_type, AS, IsDecorated> &&other) {
         m_ptr = other.m_ptr;
+        return *this;
     }
 
     reference operator[](std::ptrdiff_t i) const { return m_ptr[i]; }
@@ -411,8 +413,14 @@ class SIMSYCL_DETAIL_DEPRECATED_IN_SYCL multi_ptr<ElementType, Space, access::de
     // Assignment and access operators
     multi_ptr &operator=(const multi_ptr &) = default;
     multi_ptr &operator=(multi_ptr &&) = default;
-    multi_ptr &operator=(pointer_t ptr) { m_ptr = ptr; }
-    multi_ptr &operator=(std::nullptr_t /* nullptr */) { m_ptr = nullptr; }
+    multi_ptr &operator=(pointer_t ptr) {
+        m_ptr = ptr;
+        return *this;
+    }
+    multi_ptr &operator=(std::nullptr_t /* nullptr */) {
+        m_ptr = nullptr;
+        return *this;
+    }
 
     ElementType *operator->() const { return m_ptr; }
 
@@ -556,8 +564,14 @@ class SIMSYCL_DETAIL_DEPRECATED_IN_SYCL
     // Assignment operators
     multi_ptr &operator=(const multi_ptr &) = default;
     multi_ptr &operator=(multi_ptr &&) = default;
-    multi_ptr &operator=(pointer_t ptr) { m_ptr = ptr; }
-    multi_ptr &operator=(std::nullptr_t /* nullptr */) { m_ptr = nullptr; }
+    multi_ptr &operator=(pointer_t ptr) {
+        m_ptr = ptr;
+        return *this;
+    }
+    multi_ptr &operator=(std::nullptr_t /* nullptr */) {
+        m_ptr = nullptr;
+        return *this;
+    }
 
     template<typename ElementType, int Dimensions, access_mode Mode, access::placeholder IsPlaceholder>
         requires(Space == access::address_space::global_space || Space == access::address_space::generic_space)

--- a/src/simsycl/queue.cc
+++ b/src/simsycl/queue.cc
@@ -18,8 +18,8 @@ struct queue_state {
 
     queue_state(const sycl::device &device, const sycl::context &context, const sycl::async_handler &async_handler)
         : device(device), context(context), async_handler(async_handler) {
-        SIMSYCL_CHECK_MSG(std::find(context.get_devices().begin(), context.get_devices().end(), device)
-                != context.get_devices().end(),
+        const auto devices = context.get_devices();
+        SIMSYCL_CHECK_MSG(std::find(devices.begin(), devices.end(), device) != devices.end(),
             "queue::queue(): selected device is not in provided context");
     }
 

--- a/src/simsycl/queue.cc
+++ b/src/simsycl/queue.cc
@@ -18,8 +18,8 @@ struct queue_state {
 
     queue_state(const sycl::device &device, const sycl::context &context, const sycl::async_handler &async_handler)
         : device(device), context(context), async_handler(async_handler) {
-        const auto devices = context.get_devices();
-        SIMSYCL_CHECK_MSG(std::find(devices.begin(), devices.end(), device) != devices.end(),
+        SIMSYCL_CHECK_MSG(
+            [ds = context.get_devices()](auto &d) { return std::find(ds.begin(), ds.end(), d) != ds.end(); }(device),
             "queue::queue(): selected device is not in provided context");
     }
 


### PR DESCRIPTION
- `multi_ptr &operator=` should return `*this`
- `context::get_devices` returns a temporary, so we should not mix iterators from multiple calls to it.