### PR TITLE
Throw `sycl::exception` on invalid call to `get_property()`

### DIFF
--- a/include/simsycl/sycl/property.hh
+++ b/include/simsycl/sycl/property.hh
@@ -12,7 +12,10 @@ namespace simsycl::detail {
 
 class property_interface;
 
-}
+// outlined into check.cc to avoid cyclic include property.hh -> exception.hh -> context.hh -> property.hh
+[[noreturn]] void throw_invalid_property();
+
+} // namespace simsycl::detail
 
 namespace simsycl::sycl {
 
@@ -46,7 +49,7 @@ class property_list {
     Property get_property() const {
         const auto iter = std::find_if(m_properties.begin(), m_properties.end(),
             [](const std::any &prop) { return prop.type() == typeid(Property); });
-        SIMSYCL_CHECK(iter != m_properties.end());
+        if(iter == m_properties.end()) { detail::throw_invalid_property(); }
         return std::any_cast<Property>(*iter);
     }
 
@@ -101,7 +104,7 @@ class property_interface {
     Property get_property() const {
         const auto iter = std::find_if(m_properties.begin(), m_properties.end(),
             [](const std::any &prop) { return prop.type() == typeid(Property); });
-        SIMSYCL_CHECK(iter != m_properties.end());
+        if(iter == m_properties.end()) { detail::throw_invalid_property(); }
         return std::any_cast<Property>(*iter);
     }
 

--- a/src/simsycl/check.cc
+++ b/src/simsycl/check.cc
@@ -1,5 +1,6 @@
 #include "simsycl/detail/check.hh"
 #include "simsycl/sycl/exception.hh"
+#include "simsycl/sycl/property.hh"
 
 // TODO: use std::format/print once widely available
 #include <cassert>
@@ -49,6 +50,10 @@ void check(bool condition, const char *cond_string, std::source_location locatio
             default: assert(false && "invalid check mode");
         }
     }
+}
+
+void throw_invalid_property() {
+    throw simsycl::sycl::exception(sycl::errc::invalid, "object does not hold requested property");
 }
 
 } // namespace simsycl::detail


### PR DESCRIPTION
Spec requires us to throw `errc::invalid`, instead of triggering a SimSYCL check as we do currently.

Found by CTS `queue` test.