### PR TITLE
Fix CMP0167 CMake warning

### DIFF
--- a/.github/workflows/simsycl_ci.yml
+++ b/.github/workflows/simsycl_ci.yml
@@ -80,6 +80,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_POLICY_DEFAULT_CMP0144=NEW
         -S ${{ github.workspace }}
         -DCMAKE_INSTALL_PREFIX=${{ steps.strings.outputs.install-dir }}
 
@@ -95,6 +96,7 @@ jobs:
         -DCMAKE_CXX_COMPILER=${{ matrix.cpp_compiler }}
         -DCMAKE_C_COMPILER=${{ matrix.c_compiler }}
         -DCMAKE_BUILD_TYPE=${{ matrix.build_type }}
+        -DCMAKE_POLICY_DEFAULT_CMP0144=NEW
         -S ${{ github.workspace }}/examples
         -DCMAKE_PREFIX_PATH=${{ steps.strings.outputs.install-dir }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ if(CMAKE_GENERATOR STREQUAL "Ninja")
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fdiagnostics-color=always")
 endif()
 
-find_package(Boost 1.70 COMPONENTS context REQUIRED)
+find_package(Boost 1.70 CONFIG COMPONENTS context REQUIRED)
 
 include(FetchContent)
 

--- a/cmake/simsycl-config.cmake.in
+++ b/cmake/simsycl-config.cmake.in
@@ -14,7 +14,7 @@ set(SIMSYCL_LIBRARY SimSYCL::simsycl)
 set(SIMSYCL_ORIGINAL_CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}")
 set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH}" "${SIMSYCL_CMAKE_DIR}")
 
-find_dependency(Boost 1.70 COMPONENTS context REQUIRED)
+find_dependency(Boost 1.70 CONFIG COMPONENTS context REQUIRED)
 find_dependency(nlohmann_json)
 find_dependency(libenvpp)
 


### PR DESCRIPTION
This fixes the [CMP0167](https://cmake.org/cmake/help/latest/policy/CMP0167.html) warning for SimSYCL and all consuming projects with any recent CMake version.
Since we already require Boost 1.70, we need no fallback or additional handling.

To make it work in CI, I also had to enable CMP0144 (which should eventually become the default behaviour as far as I understand it). I didn't run into this issue locally.