### PR TITLE
Fix vec constructors

### DIFF
--- a/include/simsycl/sycl/vec.hh
+++ b/include/simsycl/sycl/vec.hh
@@ -515,7 +515,7 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
 
     vec() = default;
 
-    explicit constexpr vec(const DataT &arg) {
+    explicit(num_elements > 1) constexpr vec(const DataT &arg) {
         for(int i = 0; i < NumElements; ++i) { m_elems[i] = arg; }
     }
 


### PR DESCRIPTION
This is part of a series of four consecutive pull requests implementing some of the SYCL clarifications for `sycl::vec`.

This pull request implements the behavior specified in https://github.com/KhronosGroup/SYCL-Docs/pull/668#issue-2715744864, which fixes `sycl::vec` constructors.