### PR TITLE
Add explicit vec conversion

### DIFF
--- a/include/simsycl/sycl/vec.hh
+++ b/include/simsycl/sycl/vec.hh
@@ -69,6 +69,8 @@ template<typename T, typename DataT, int NumElements>
 concept VecCompatible
     = vec_like_num_elements<DataT, T>::value == 1 || vec_like_num_elements<DataT, T>::value == NumElements;
 
+template<typename From, typename To>
+concept explicitly_convertible_to = requires { static_cast<To>(std::declval<From>()); };
 
 template<int... Is>
 struct no_repeat_indices;
@@ -256,6 +258,13 @@ class swizzled_vec {
     }
 
     operator value_type() const
+        requires(num_elements == 1)
+    {
+        return m_elems[indices[0]];
+    }
+
+    template<detail::explicitly_convertible_to<value_type> T>
+    explicit operator T() const
         requires(num_elements == 1)
     {
         return m_elems[indices[0]];
@@ -543,6 +552,13 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
     }
 
     operator DataT() const
+        requires(NumElements == 1)
+    {
+        return m_elems[0];
+    }
+
+    template<detail::explicitly_convertible_to<DataT> T>
+    explicit operator T() const
         requires(NumElements == 1)
     {
         return m_elems[0];


### PR DESCRIPTION
This is the second part of a series of four pull requests addressing some SYCL clarifications for sycl::vec.

This pull request implements the behavior specified in https://github.com/KhronosGroup/SYCL-Docs/pull/669#issue-2715756663, which adds explicit vec conversions.