### PR TITLE
Change the return type of named swizzles

### DIFF
--- a/include/simsycl/sycl/vec.hh
+++ b/include/simsycl/sycl/vec.hh
@@ -69,6 +69,8 @@ template<typename T, typename DataT, int NumElements>
 concept VecCompatible
     = vec_like_num_elements<DataT, T>::value == 1 || vec_like_num_elements<DataT, T>::value == NumElements;
 
+template<typename From, typename To>
+concept explicitly_convertible_to = requires { static_cast<To>(std::declval<From>()); };
 
 template<int... Is>
 struct no_repeat_indices;
@@ -256,6 +258,13 @@ class swizzled_vec {
     }
 
     operator value_type() const
+        requires(num_elements == 1)
+    {
+        return m_elems[indices[0]];
+    }
+
+    template<detail::explicitly_convertible_to<value_type> T>
+    explicit operator T() const
         requires(num_elements == 1)
     {
         return m_elems[indices[0]];
@@ -543,6 +552,13 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
     }
 
     operator DataT() const
+        requires(NumElements == 1)
+    {
+        return m_elems[0];
+    }
+
+    template<detail::explicitly_convertible_to<DataT> T>
+    explicit operator T() const
         requires(NumElements == 1)
     {
         return m_elems[0];

--- a/include/simsycl/sycl/vec.hh
+++ b/include/simsycl/sycl/vec.hh
@@ -7,6 +7,7 @@
 #include "../detail/check.hh"
 #include "../detail/utils.hh"
 
+#include <concepts>
 #include <cstdint>
 #include <cstdlib>
 #include <type_traits>
@@ -231,7 +232,8 @@ class swizzled_vec {
     swizzled_vec &operator=(const swizzled_vec &) = delete;
     swizzled_vec &operator=(swizzled_vec &&) = delete;
 
-    swizzled_vec &operator=(const value_type &rhs)
+    template<std::convertible_to<value_type> T>
+    swizzled_vec &operator=(const T &rhs)
         requires(allow_assign)
     {
         for(size_t i = 0; i < num_elements; ++i) { m_elems[indices[i]] = rhs; }
@@ -537,7 +539,8 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
     vec(const vec &) = default;
     vec &operator=(const vec &rhs) = default;
 
-    vec &operator=(const DataT &rhs) {
+    template<std::convertible_to<DataT> T>
+    vec &operator=(const T &rhs) {
         for(int i = 0; i < NumElements; ++i) { m_elems[i] = rhs; }
         return *this;
     }
@@ -752,14 +755,16 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
         for(int i = 0; i < NumElements; ++i) { result.m_elems[i] = lhs.m_elems[i] op rhs.m_elems[i]; }                 \
         return result;                                                                                                 \
     }                                                                                                                  \
-    friend vec operator op(const vec &lhs, const DataT &rhs)                                                           \
+    template<std::convertible_to<DataT> T>                                                                             \
+    friend vec operator op(const vec &lhs, const T &rhs)                                                               \
         requires(enable_if)                                                                                            \
     {                                                                                                                  \
         vec result;                                                                                                    \
         for(int i = 0; i < NumElements; ++i) { result.m_elems[i] = lhs.m_elems[i] op rhs; }                            \
         return result;                                                                                                 \
     }                                                                                                                  \
-    friend vec operator op(const DataT &lhs, const vec &rhs)                                                           \
+    template<std::convertible_to<DataT> T>                                                                             \
+    friend vec operator op(const T &lhs, const vec &rhs)                                                               \
         requires(enable_if)                                                                                            \
     {                                                                                                                  \
         vec result;                                                                                                    \
@@ -794,7 +799,8 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
         for(int i = 0; i < NumElements; ++i) { lhs.m_elems[i] op rhs.m_elems[rhs.indices[i]]; }                        \
         return lhs;                                                                                                    \
     }                                                                                                                  \
-    friend vec &operator op(vec & lhs, const DataT & rhs)                                                              \
+    template<std::convertible_to<DataT> T>                                                                             \
+    friend vec &operator op(vec & lhs, const T & rhs)                                                                  \
         requires(enable_if)                                                                                            \
     {                                                                                                                  \
         for(int i = 0; i < NumElements; ++i) { lhs.m_elems[i] op rhs; }                                                \
@@ -863,12 +869,14 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
         for(int i = 0; i < NumElements; ++i) { result.m_elems[i] = lhs.m_elems[i] op rhs.m_elems[i]; }                 \
         return result;                                                                                                 \
     }                                                                                                                  \
-    friend vec<decltype(DataT {} op DataT{}), NumElements> operator op(const vec & lhs, const DataT & rhs) {           \
+    template<std::convertible_to<DataT> T>                                                                             \
+    friend vec<decltype(DataT {} op DataT{}), NumElements> operator op(const vec & lhs, const T & rhs) {               \
         vec<decltype(DataT {} op DataT{}), NumElements> result;                                                        \
         for(int i = 0; i < NumElements; ++i) { result.m_elems[i] = lhs.m_elems[i] op rhs; }                            \
         return result;                                                                                                 \
     }                                                                                                                  \
-    friend vec<decltype(DataT {} op DataT{}), NumElements> operator op(const DataT & lhs, const vec & rhs) {           \
+    template<std::convertible_to<DataT> T>                                                                             \
+    friend vec<decltype(DataT {} op DataT{}), NumElements> operator op(const T & lhs, const vec & rhs) {               \
         vec<decltype(DataT {} op DataT{}), NumElements> result;                                                        \
         for(int i = 0; i < NumElements; ++i) { result.m_elems[i] = lhs op rhs.m_elems[i]; }                            \
         return result;                                                                                                 \

--- a/include/simsycl/sycl/vec.hh
+++ b/include/simsycl/sycl/vec.hh
@@ -299,10 +299,10 @@ class swizzled_vec {
     }
 
 #define SIMSYCL_DETAIL_DEFINE_1D_SWIZZLE(req, comp)                                                                    \
-    auto comp() const                                                                                                  \
+    ReferenceDataT &comp() const                                                                                       \
         requires(req && num_elements > sycl::elem::comp)                                                               \
     {                                                                                                                  \
-        return detail::swizzled_vec<ReferenceDataT, indices[sycl::elem::comp]>(m_elems);                               \
+        return m_elems[indices[sycl::elem::comp]];                                                                     \
     }
 
 #define SIMSYCL_DETAIL_DEFINE_2D_SWIZZLE(req, comp1, comp2)                                                            \
@@ -607,15 +607,15 @@ class alignas(detail::vec_alignment_v<DataT, NumElements>) vec {
     }
 
 #define SIMSYCL_DETAIL_DEFINE_1D_SWIZZLE(req, comp)                                                                    \
-    auto comp()                                                                                                        \
+    DataT &comp()                                                                                                      \
         requires(req && num_elements > elem::comp)                                                                     \
     {                                                                                                                  \
-        return detail::swizzled_vec<DataT, elem::comp>(m_elems);                                                       \
+        return m_elems[elem::comp];                                                                                    \
     }                                                                                                                  \
-    auto comp() const                                                                                                  \
+    const DataT &comp() const                                                                                          \
         requires(req && num_elements > elem::comp)                                                                     \
     {                                                                                                                  \
-        return detail::swizzled_vec<const DataT, elem::comp>(m_elems);                                                 \
+        return m_elems[elem::comp];                                                                                    \
     }
 
 #define SIMSYCL_DETAIL_DEFINE_2D_SWIZZLE(req, comp1, comp2)                                                            \

--- a/test/vec_tests.cc
+++ b/test/vec_tests.cc
@@ -158,6 +158,17 @@ TEST_CASE("Vector swizzled access is available", "[vec][swizzle]") {
         vi.even() = {11, 12};
         CHECK(check_bool_vec(vi == sycl::vec<int, 4>{11, 9, 12, 10}));
     }
+
+    SECTION("1D swizzled vec return type") {
+        sycl::vec<uint8_t, 4> v4{255};
+        CHECK(std::is_same_v<decltype(v4.x()), uint8_t &>);
+        CHECK(std::is_same_v<decltype(v4.y()), uint8_t &>);
+        CHECK(std::is_same_v<decltype(v4.z()), uint8_t &>);
+        CHECK(std::is_same_v<decltype(v4.w()), uint8_t &>);
+
+        int i = (v4.x() + 1);
+        CHECK(i == 256);
+    }
 }
 
 TEST_CASE("Operations on swizzled vectors work as expected", "[vec][swizzle]") {
@@ -208,7 +219,7 @@ TEST_CASE("Operations on swizzled vectors work as expected", "[vec][swizzle]") {
         CHECK(check_bool_vec(sycl::vec<int, 2>{0, 0} < vi.xy()));
 
         CHECK(check_bool_vec(vi.zw() < 10));
-        CHECK(check_bool_vec(vi.z() == 3));
-        CHECK(check_bool_vec(4 == vi.a()));
+        CHECK((vi.z() == 3));
+        CHECK((4 == vi.a()));
     }
 }


### PR DESCRIPTION
This is the fourth and last part of a series of four pull requests addressing some SYCL clarifications for `sycl::vec`.

This pull request implements the behavior specified in https://github.com/KhronosGroup/SYCL-Docs/pull/672#issue-2715771214, which changes the return type of 1-element named swizzles to `DataT &`.