### PR TITLE
Implementation of SYCL_KHR_QUEUE_FLUSH

### DIFF
--- a/include/simsycl/sycl/queue.hh
+++ b/include/simsycl/sycl/queue.hh
@@ -8,6 +8,7 @@
 #include "../detail/lock.hh"
 #include "../detail/reference_type.hh"
 
+#define SYCL_KHR_QUEUE_FLUSH 1
 
 namespace simsycl::sycl::property::queue {
 
@@ -88,6 +89,8 @@ class queue final : public detail::reference_type<queue, detail::queue_state>,
     context get_context() const;
 
     device get_device() const;
+
+    void khr_flush() const;
 
     bool is_in_order() const { return has_property<property::queue::in_order>(); }
 

--- a/src/simsycl/queue.cc
+++ b/src/simsycl/queue.cc
@@ -69,4 +69,6 @@ context queue::get_context() const { return state().context; }
 
 device queue::get_device() const { return state().device; }
 
+void queue::khr_flush() const {}
+
 } // namespace simsycl::sycl


### PR DESCRIPTION
Hi,

I implemented [SYCL_KHR_QUEUE_FLUSH](https://github.com/KhronosGroup/SYCL-Docs/blob/8600aad43effe73295cfb862b399b2c49546ee0c/adoc/extensions/sycl_khr_queue_flush.adoc).

As SimSYCL use greedy execution by default, this is a no-op. (Please note that I didn't add any tests because of that)

Thanks!

And please excuse me in advance for any problem in this PR : ) 

Regards,
Thomas